### PR TITLE
fix: add redirect back to studio page to prevent 404 error

### DIFF
--- a/app/routes/studio/$.tsx
+++ b/app/routes/studio/$.tsx
@@ -5,6 +5,13 @@ import { redirect } from '@remix-run/server-runtime';
 export async function loader({ params }: LoaderArgs) {
     console.log({ params });
 
+    // Currently with Studio V2 we can't host it as a subdirectory with Remix seamlessly.
+    // When a user navigates to the /studio route then the Studio will load up okay and the
+    // user can access everything.
+    // However if they directly access /studio/desk (for example) or refresh the page then
+    // Remix will take over and throw a 404 error.
+    // Adding this redirect allows us to push the page back to the Sanity Studio startup page
+    // and the catch boundry is there as a safety net.
     return redirect('/studio');
 }
 

--- a/app/routes/studio/$.tsx
+++ b/app/routes/studio/$.tsx
@@ -1,12 +1,11 @@
+import type { LoaderArgs } from '@remix-run/server-runtime';
 import { useCatch } from '@remix-run/react';
+import { redirect } from '@remix-run/server-runtime';
 
-export async function loader() {
-    // This page should always through a 404 error
-    // Remix router is intefering with the Sanity Studio route so pages access directly or refreshed will errror
-    // This allows us to handle that nicely and direct users to the correct url
-    throw new Response('Not Found', {
-        status: 404
-    });
+export async function loader({ params }: LoaderArgs) {
+    console.log({ params });
+
+    return redirect('/studio');
 }
 
 export function CatchBoundary() {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

Adds redirect to studio splat route to redirect a refreshed page back to the studio startup -- prevents 404 error when page is refreshed

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for users. -->

## 📝 Additional Information
