### PR TITLE
fix: adds condition to update the page state when the id changes

### DIFF
--- a/app/routes/collections/$slug.tsx
+++ b/app/routes/collections/$slug.tsx
@@ -56,6 +56,9 @@ export default function Collection() {
     // If `preview` mode is active, its component update this state for us
     const [data, setData] = useState(collection);
 
+    // Make sure to update the page state if the IDs are different!
+    if (collection._id !== data._id) setData(collection);
+
     const title = data?.store?.title;
 
     // NOTE: For preview mode to work nicely when working with draft content, optional chain _everything_

--- a/app/routes/pages/$slug.tsx
+++ b/app/routes/pages/$slug.tsx
@@ -50,6 +50,9 @@ export default function Page() {
     // If `preview` mode is active, its component update this state for us
     const [data, setData] = useState(page);
 
+    // Make sure to update the page state if the IDs are different!
+    if (page._id !== data._id) setData(page);
+
     // NOTE: For preview mode to work nicely when working with draft content, optional chain _everything_
     return (
         <>

--- a/app/routes/products/$slug.tsx
+++ b/app/routes/products/$slug.tsx
@@ -48,6 +48,9 @@ export default function Product() {
     // If `preview` mode is active, its component update this state for us
     const [data, setData] = useState(product);
 
+    // Make sure to update the page state if the IDs are different!
+    if (product._id !== data._id) setData(product);
+
     const title = data?.store?.title;
 
     // NOTE: For preview mode to work nicely when working with draft content, optional chain _everything_


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

Fixes a bug where if you navigate between pages in the same route, e.g. /pages/page-1 and /pages/page-2 the page won't update due to the state hook not changing.

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for users. -->

## 📝 Additional Information
