### PR TITLE
Fix/high api queries

### DIFF
--- a/app/components/footer/Footer.tsx
+++ b/app/components/footer/Footer.tsx
@@ -6,9 +6,7 @@ import Navigation from '../navigation/Navigation';
 export default function Footer() {
     const matches = useMatches();
 
-    const footerData = matches
-        .filter((match) => match.id === 'root')
-        .map((match) => match.data.footerText);
+    const footerData = matches.find((match) => match.data.footerText)?.data.footerText;
 
     return (
         <footer className="u-bg-secondary">
@@ -28,7 +26,7 @@ export default function Footer() {
                     <Spacer />
 
                     <Box>
-                        <PortableText value={footerData[0]} />
+                        <PortableText value={footerData} />
                     </Box>
                 </Flex>
             </Box>

--- a/app/components/navigation/Navigation.tsx
+++ b/app/components/navigation/Navigation.tsx
@@ -48,18 +48,15 @@ export default function Navigation({ menuItemsName }: Props) {
     // https://remix.run/docs/en/v1/api/remix#usematches
     const matches = useMatches();
 
-    const menuItems = matches
-        .filter((match) => match.id === 'root')
-        .map((match) =>
-            menuItemsName === 'headerMenuItems'
-                ? match.data.headerMenuItems
-                : match.data.footerMenuItems
-        );
+    const menuItems =
+        menuItemsName === 'headerMenuItems'
+            ? matches.find((match) => match.data.headerMenuItems)?.data.headerMenuItems
+            : matches.find((match) => match.data.footerMenuItems)?.data.footerMenuItems;
 
     return (
         <nav>
             <HStack as="ul" spacing={4}>
-                {menuItems[0]?.links?.map((menuItem: MenuItem) => (
+                {menuItems?.links?.map((menuItem: MenuItem) => (
                     <li className="" key={menuItem._key}>
                         {menuItem._type === 'linkInternal' ? (
                             <InternalMenuItem menuItem={menuItem} />

--- a/app/models/sanity.server.ts
+++ b/app/models/sanity.server.ts
@@ -1,4 +1,5 @@
 import type { Params } from 'react-router-dom';
+import type { SanitySiteSetting } from '~/types';
 import { getClient } from '~/lib/sanity/getClient.server';
 
 interface Args {
@@ -27,6 +28,27 @@ export default async function getPageData({ request, params, query }: Args) {
         })[0];
 
         return { page: pageData, isPreview };
+    } catch (err) {
+        console.error(err);
+    }
+}
+
+export async function getSettingsData({ query }: { query: string }) {
+    if (!query) throw new Error('Query must be passed');
+
+    try {
+        const siteSettings = await getClient().fetch(query);
+        const liveSettings = siteSettings.filter(
+            (setting: SanitySiteSetting) => !setting._id.includes('drafts')
+        )[0];
+
+        const headerMenuItems = liveSettings?.menu;
+        const footerSettings = liveSettings?.footer;
+
+        return {
+            headerMenuItems,
+            footerSettings
+        };
     } catch (err) {
         console.error(err);
     }

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -26,9 +26,6 @@ import { getUser } from './session.server';
 import { checkConnectivity } from '~/utils/client/pwa-utils.client';
 import Header from './components/header/Header';
 import Footer from './components/footer/Footer';
-import type { SanityLinkItem, SanitySiteSetting } from '~/types';
-import { getClient } from './lib/sanity/getClient.server';
-import { SETTINGS_QUERY } from './queries/sanity/settings';
 // push notifications not working at present, due to wrong sender ID
 // import { PushNotification } from '~/utils/server/pwa-utils.server';
 
@@ -70,25 +67,12 @@ type LoaderData = {
     nodeEnv: string;
     SANITY_STUDIO_API_PROJECT_ID: string | undefined;
     SANITY_STUDIO_API_DATASET: string | undefined;
-    headerMenuItems: SanityLinkItem[] | undefined;
-    footerMenuItems: SanityLinkItem[] | undefined;
-    footerText: object[] | undefined;
 };
 
 export const headers: HeadersFunction = () => ({
     'Accept-CH': 'Sec-CH-Prefers-Color-Scheme'
 });
 export const loader: LoaderFunction = async ({ request }) => {
-    const siteSettings = await getClient()
-        .fetch(SETTINGS_QUERY)
-        .catch((err) => console.error(err));
-    const liveSettings = siteSettings.filter(
-        (setting: SanitySiteSetting) => !setting._id.includes('drafts')
-    )[0];
-
-    const headerMenuItems = liveSettings?.menu;
-    const footerMenuItems = liveSettings?.footer;
-
     return json<LoaderData>({
         user: await getUser(request),
         colorScheme: await getColorScheme(request),
@@ -98,10 +82,7 @@ export const loader: LoaderFunction = async ({ request }) => {
             process.env.NODE_ENV === 'production' ? process.env.GTM_TRACKING_ID : undefined,
         nodeEnv: process.env.NODE_ENV === 'production' ? 'production' : 'development',
         SANITY_STUDIO_API_PROJECT_ID: process.env.SANITY_STUDIO_API_PROJECT_ID,
-        SANITY_STUDIO_API_DATASET: process.env.SANITY_STUDIO_API_DATASET,
-        headerMenuItems,
-        footerMenuItems,
-        footerText: liveSettings?.footer?.text
+        SANITY_STUDIO_API_DATASET: process.env.SANITY_STUDIO_API_DATASET
     });
 };
 interface DocumentProps {

--- a/app/routes/collections/$slug.tsx
+++ b/app/routes/collections/$slug.tsx
@@ -9,12 +9,19 @@ import Module from '~/components/module';
 import Preview from '~/components/Preview';
 import { VStack } from '@chakra-ui/react';
 import ProductGrid from '~/components/collections/ProdutGrid';
-import getPageData from '~/models/sanity.server';
+import getPageData, { getSettingsData } from '~/models/sanity.server';
 import { COLLECTION_QUERY } from '~/queries/sanity/collection';
+import { SETTINGS_QUERY } from '~/queries/sanity/settings';
 
 export async function loader({ request, params }: LoaderArgs) {
     if (!params.slug) throw new Error('Missing slug');
 
+    // Query the site settings
+    const siteSettings = await getSettingsData({
+        query: SETTINGS_QUERY
+    });
+
+    // Query the page data
     const data = await getPageData({
         request,
         params,
@@ -29,6 +36,9 @@ export async function loader({ request, params }: LoaderArgs) {
     const { products } = queryProducts?.collection;
 
     return json({
+        headerMenuItems: siteSettings?.headerMenuItems,
+        footerMenuItems: siteSettings?.footerSettings,
+        footerText: siteSettings?.footerSettings?.text,
         collection,
         products,
         isPreview,

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -1,3 +1,4 @@
+import type { SanitySiteSetting } from '~/types';
 import { useState } from 'react';
 import { json } from '@remix-run/node';
 import type { LoaderArgs, MetaFunction } from '@remix-run/node';
@@ -10,11 +11,18 @@ import { VStack } from '@chakra-ui/react';
 import Module from '~/components/module';
 import type { module } from '~/types';
 import { HOME_QUERY } from '~/queries/sanity/home';
-import getPageData from '~/models/sanity.server';
+import getPageData, { getSettingsData } from '~/models/sanity.server';
+import { SETTINGS_QUERY } from '~/queries/sanity/settings';
 
 export const loader: LoaderFunction = async ({ request, params }: LoaderArgs) => {
     const colorScheme = await getColorScheme(request);
 
+    // Query the site settings
+    const siteSettings = await getSettingsData({
+        query: SETTINGS_QUERY
+    });
+
+    // Query the page data
     const data = await getPageData({
         request,
         query: HOME_QUERY
@@ -25,6 +33,9 @@ export const loader: LoaderFunction = async ({ request, params }: LoaderArgs) =>
 
     return json({
         colorScheme,
+        headerMenuItems: siteSettings?.headerMenuItems,
+        footerMenuItems: siteSettings?.footerSettings,
+        footerText: siteSettings?.footerSettings?.text,
         home,
         isPreview,
         query: isPreview ? HOME_QUERY : null

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -1,4 +1,3 @@
-import type { SanitySiteSetting } from '~/types';
 import { useState } from 'react';
 import { json } from '@remix-run/node';
 import type { LoaderArgs, MetaFunction } from '@remix-run/node';

--- a/app/routes/pages/$slug.tsx
+++ b/app/routes/pages/$slug.tsx
@@ -7,11 +7,16 @@ import { VStack } from '@chakra-ui/react';
 import Hero from '~/components/hero/Hero';
 import Module from '~/components/module';
 import Preview from '~/components/Preview';
-import getPageData from '~/models/sanity.server';
+import getPageData, { getSettingsData } from '~/models/sanity.server';
 import { PAGE_QUERY } from '~/queries/sanity/page';
+import { SETTINGS_QUERY } from '~/queries/sanity/settings';
 
 export async function loader({ request, params }: LoaderArgs) {
     if (!params.slug) throw new Error('Missing slug');
+
+    const siteSettings = await getSettingsData({
+        query: SETTINGS_QUERY
+    });
 
     const data = await getPageData({
         request,
@@ -23,6 +28,9 @@ export async function loader({ request, params }: LoaderArgs) {
     const { page, isPreview } = data;
 
     return json({
+        headerMenuItems: siteSettings?.headerMenuItems,
+        footerMenuItems: siteSettings?.footerSettings,
+        footerText: siteSettings?.footerSettings?.text,
         page,
         isPreview,
         // If `preview` mode is active, we'll need these for live updates
@@ -52,7 +60,6 @@ export default function Page() {
 
     // Make sure to update the page state if the IDs are different!
     if (page._id !== data._id) setData(page);
-
 
     // NOTE: For preview mode to work nicely when working with draft content, optional chain _everything_
     return (

--- a/app/routes/products/$slug.tsx
+++ b/app/routes/products/$slug.tsx
@@ -6,12 +6,19 @@ import { useLoaderData, useParams } from '@remix-run/react';
 import Module from '~/components/module';
 import Preview from '~/components/Preview';
 import { VStack } from '@chakra-ui/react';
-import getPageData from '~/models/sanity.server';
+import getPageData, { getSettingsData } from '~/models/sanity.server';
 import { PRODUCT_QUERY } from '~/queries/sanity/product';
+import { SETTINGS_QUERY } from '~/queries/sanity/settings';
 
 export async function loader({ request, params }: LoaderArgs) {
     if (!params.slug) throw new Error('Missing slug');
 
+    // Query the site settings
+    const siteSettings = await getSettingsData({
+        query: SETTINGS_QUERY
+    });
+
+    // Query the page data
     const data = await getPageData({
         request,
         params,
@@ -22,6 +29,9 @@ export async function loader({ request, params }: LoaderArgs) {
     const { page: product, isPreview } = data;
 
     return json({
+        headerMenuItems: siteSettings?.headerMenuItems,
+        footerMenuItems: siteSettings?.footerSettings,
+        footerText: siteSettings?.footerSettings?.text,
         product,
         isPreview,
         // If `preview` mode is active, we'll need these for live updates


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

We found that we were having very high api calls to our Sanity dataset 30-50k a day. After some research it appears that this is being caused by the global settings query in the `root.tsx` file getting queried on our `/healthcheck` route, which is called by fly.io every 10 seconds.

Here we are removing the settings query from the `root.tsx` file and creating an abstraction we can use across the routes instead.

## ⛳️ Current behavior (updates)

Sanity settings query is queried from the `root.tsx` file and the settings are gathered by the `useMatches` hook in the appropriate components.

## 🚀 New behavior

The settings query is now queried within each of the route individually using a `getSettingsData` helper.
I have also updated the useMatches in the Navigation and Footer components to use the `.find` array method to simplify the loop, rather than trying to target each id like before.

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for users. -->

## 📝 Additional Information
